### PR TITLE
Update rust.yml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,8 +17,6 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - beta
-          - nightly 
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
I removed builds for the beta and nightly versions for rust. These versions change very frequently and may not be compatible with some features already implemented in the stable rust version.